### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,20 +6,20 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Button       KEYWORD1
+Button	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-read         KEYWORD2
-toggled      KEYWORD2
-pressed      KEYWORD2
-released     KEYWORD2
-has_changed  KEYWORD2
+read	KEYWORD2
+toggled	KEYWORD2
+pressed	KEYWORD2
+released	KEYWORD2
+has_changed	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
-PRESSED      LITERAL1
-RELEASED     LITERAL1
+PRESSED	LITERAL1
+RELEASED	LITERAL1


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords